### PR TITLE
feat: support min and max Date inputs for dateString()

### DIFF
--- a/dateString.js
+++ b/dateString.js
@@ -12,6 +12,11 @@ function dateString(input, opts) {
   opts = opts || 0
   var minDate, maxDate
 
+  // keep older dateString function for backwards compatibility
+  if (!opts || (opts.minYear && opts.maxYear)) {
+    return dateStringLegacy(input, opts)
+  }
+
   if (opts.min) {
     minDate = new Date(opts.min)
   } else {
@@ -32,6 +37,26 @@ function dateString(input, opts) {
   var time = fit(id, min, max)
 
   return new Date(time).toISOString()
+}
+
+function dateStringLegacy(input, opts) {
+  var id = hash(input)
+
+  opts = opts || 0
+  var minYear = defaults(opts.minYear, MIN_YEAR)
+  var maxYear = defaults(opts.maxYear, MAX_YEAR)
+
+  // for simplicity, use 28d as max regardless of month/year
+  var year = fit(id, minYear, maxYear)
+  var monthIndex = fit(id, 0, 11)
+  var day = fit(id, 1, 28)
+  var hour = fit(id, 0, 23)
+  var min = fit(id, 0, 59)
+  var millisec = fit(id, 0, 1000)
+
+  return new Date(
+    Date.UTC(year, monthIndex, day, hour, min, millisec)
+  ).toISOString()
 }
 
 dateString.options = function dateStringOptions(opts) {

--- a/dateString.js
+++ b/dateString.js
@@ -10,20 +10,28 @@ function dateString(input, opts) {
   var id = hash(input)
 
   opts = opts || 0
-  var minYear = defaults(opts.minYear, MIN_YEAR)
-  var maxYear = defaults(opts.maxYear, MAX_YEAR)
+  var minDate, maxDate
 
-  // for simplicity, use 28d as max regardless of month/year
-  var year = fit(id, minYear, maxYear)
-  var monthIndex = fit(id, 0, 11)
-  var day = fit(id, 1, 28)
-  var hour = fit(id, 0, 23)
-  var min = fit(id, 0, 59)
-  var millisec = fit(id, 0, 1000)
+  if (opts.min) {
+    minDate = new Date(opts.min)
+  } else {
+    var minYear = defaults(opts.minYear, MIN_YEAR)
+    minDate = new Date(Date.UTC(minYear, 0, 1))
+  }
 
-  return new Date(
-    Date.UTC(year, monthIndex, day, hour, min, millisec)
-  ).toISOString()
+  if (opts.max) {
+    maxDate = new Date(opts.max)
+  } else {
+    var maxYear = defaults(opts.maxYear, MAX_YEAR)
+    maxDate = new Date(Date.UTC(maxYear, 11, 31, 23, 59, 59, 999))
+  }
+
+  var min = minDate.getTime()
+  var max = maxDate.getTime()
+
+  var time = fit(id, min, max)
+
+  return new Date(time).toISOString()
 }
 
 dateString.options = function dateStringOptions(opts) {

--- a/dateString.js
+++ b/dateString.js
@@ -13,7 +13,12 @@ function dateString(input, opts) {
   var minDate, maxDate
 
   // keep older dateString function for backwards compatibility
-  if (!opts || (opts.minYear && opts.maxYear)) {
+  if (
+    !opts ||
+    (opts.minYear && opts.minYear) ||
+    (opts.minYear && !opts.max) ||
+    (!opts.min && opts.maxYear)
+  ) {
     return dateStringLegacy(input, opts)
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,8 @@ export { float }
 export interface DateStringOptions {
   minYear: number
   maxYear: number
+  min: Date | string
+  max: Date | string
 }
 
 export interface DateString {
@@ -278,158 +280,158 @@ export type TupleReturnType<Makers extends AnyMakers> = Makers extends Makers1<
   : Makers extends Makers5<infer V1, infer V2, infer V3, infer V4, infer V5>
   ? [V1, V2, V3, V4, V5]
   : Makers extends Makers6<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6
+  >
   ? [V1, V2, V3, V4, V5, V6]
   : Makers extends Makers7<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7
+  >
   ? [V1, V2, V3, V4, V5, V6, V7]
   : Makers extends Makers8<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8]
   : Makers extends Makers9<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9]
   : Makers extends Makers10<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10]
   : Makers extends Makers11<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10,
-      infer V11
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10,
+    infer V11
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11]
   : Makers extends Makers12<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10,
-      infer V11,
-      infer V12
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10,
+    infer V11,
+    infer V12
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12]
   : Makers extends Makers13<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10,
-      infer V11,
-      infer V12,
-      infer V13
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10,
+    infer V11,
+    infer V12,
+    infer V13
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13]
   : Makers extends Makers14<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10,
-      infer V11,
-      infer V12,
-      infer V13,
-      infer V14
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10,
+    infer V11,
+    infer V12,
+    infer V13,
+    infer V14
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14]
   : Makers extends Makers15<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10,
-      infer V11,
-      infer V12,
-      infer V13,
-      infer V14,
-      infer V15
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10,
+    infer V11,
+    infer V12,
+    infer V13,
+    infer V14,
+    infer V15
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15]
   : Makers extends Makers16<
-      infer V1,
-      infer V2,
-      infer V3,
-      infer V4,
-      infer V5,
-      infer V6,
-      infer V7,
-      infer V8,
-      infer V9,
-      infer V10,
-      infer V11,
-      infer V12,
-      infer V13,
-      infer V14,
-      infer V15,
-      infer V16
-    >
+    infer V1,
+    infer V2,
+    infer V3,
+    infer V4,
+    infer V5,
+    infer V6,
+    infer V7,
+    infer V8,
+    infer V9,
+    infer V10,
+    infer V11,
+    infer V12,
+    infer V13,
+    infer V14,
+    infer V15,
+    infer V16
+  >
   ? [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16]
   : never
 
@@ -484,14 +486,14 @@ type Makers7<
   V6 = any,
   V7 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>
+  ]
 type Makers8<
   V1 = any,
   V2 = any,
@@ -502,15 +504,15 @@ type Makers8<
   V7 = any,
   V8 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>
+  ]
 type Makers9<
   V1 = any,
   V2 = any,
@@ -522,16 +524,16 @@ type Makers9<
   V8 = any,
   V9 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>
+  ]
 type Makers10<
   V1 = any,
   V2 = any,
@@ -544,17 +546,17 @@ type Makers10<
   V9 = any,
   V10 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>
+  ]
 type Makers11<
   V1 = any,
   V2 = any,
@@ -568,18 +570,18 @@ type Makers11<
   V10 = any,
   V11 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>,
-  Maker<V11>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>,
+    Maker<V11>
+  ]
 type Makers12<
   V1 = any,
   V2 = any,
@@ -594,19 +596,19 @@ type Makers12<
   V11 = any,
   V12 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>,
-  Maker<V11>,
-  Maker<V12>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>,
+    Maker<V11>,
+    Maker<V12>
+  ]
 type Makers13<
   V1 = any,
   V2 = any,
@@ -622,20 +624,20 @@ type Makers13<
   V12 = any,
   V13 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>,
-  Maker<V11>,
-  Maker<V12>,
-  Maker<V13>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>,
+    Maker<V11>,
+    Maker<V12>,
+    Maker<V13>
+  ]
 type Makers14<
   V1 = any,
   V2 = any,
@@ -652,21 +654,21 @@ type Makers14<
   V13 = any,
   V14 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>,
-  Maker<V11>,
-  Maker<V12>,
-  Maker<V13>,
-  Maker<V14>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>,
+    Maker<V11>,
+    Maker<V12>,
+    Maker<V13>,
+    Maker<V14>
+  ]
 type Makers15<
   V1 = any,
   V2 = any,
@@ -684,22 +686,22 @@ type Makers15<
   V14 = any,
   V15 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>,
-  Maker<V11>,
-  Maker<V12>,
-  Maker<V13>,
-  Maker<V14>,
-  Maker<V15>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>,
+    Maker<V11>,
+    Maker<V12>,
+    Maker<V13>,
+    Maker<V14>,
+    Maker<V15>
+  ]
 type Makers16<
   V1 = any,
   V2 = any,
@@ -718,23 +720,23 @@ type Makers16<
   V15 = any,
   V16 = any
 > = [
-  Maker<V1>,
-  Maker<V2>,
-  Maker<V3>,
-  Maker<V4>,
-  Maker<V5>,
-  Maker<V6>,
-  Maker<V7>,
-  Maker<V8>,
-  Maker<V9>,
-  Maker<V10>,
-  Maker<V11>,
-  Maker<V12>,
-  Maker<V13>,
-  Maker<V14>,
-  Maker<V15>,
-  Maker<V16>
-]
+    Maker<V1>,
+    Maker<V2>,
+    Maker<V3>,
+    Maker<V4>,
+    Maker<V5>,
+    Maker<V6>,
+    Maker<V7>,
+    Maker<V8>,
+    Maker<V9>,
+    Maker<V10>,
+    Maker<V11>,
+    Maker<V12>,
+    Maker<V13>,
+    Maker<V14>,
+    Maker<V15>,
+    Maker<V16>
+  ]
 
 declare const expandRange: (a: number, b: number) => number[]
 

--- a/readme.md
+++ b/readme.md
@@ -357,12 +357,30 @@ representing a date in
 [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
 format.
 
+Not providing `options` will default to `minYear=1980` and `maxYear=2019` for
+backwards compatibility.
+
+If you provide no options or `minYear` and `maxYear`, generated dates will be
+restricted to be between the 1st and 28th of any month.
+
 ```js
 dateString('id-23')
 // => '1989-02-18T02:01:32.000Z'
 ```
 
 ##### `options`
+
+- **`min='2024-01-01T00:00:00Z'` and `max='2024-12-31T23:59:59:999Z'`:** the
+minimum and maximum possible date values. Values can be any string that can be
+parsed directly by javascript's Date constructor or a Date object itself.
+
+```js
+dateString('id-1', {
+  min: new Date('2024-01-01T00:00:00Z')
+  max: new Date('2024-12-31T23:59:59.999Z')
+})
+// => '2024-04-01T02:39:56.220Z'
+```
 
 - **`minYear=1980` and `maxYear=2019`:** the minimum and maximum possible year
   values for returned dates

--- a/readme.md
+++ b/readme.md
@@ -376,7 +376,7 @@ parsed directly by javascript's Date constructor or a Date object itself.
 
 ```js
 dateString('id-1', {
-  min: new Date('2024-01-01T00:00:00Z')
+  min: new Date('2024-01-01T00:00:00Z'),
   max: new Date('2024-12-31T23:59:59.999Z')
 })
 // => '2024-04-01T02:39:56.220Z'

--- a/tests/dateString.test.js
+++ b/tests/dateString.test.js
@@ -15,3 +15,18 @@ test('minYear and maxYear', t => {
   }
 
 })
+
+test('min and max', t => {
+  let i = -1
+
+  while (++i < 50) {
+    const result = dateString('foo', {
+      min: new Date(2038, 0, 1),
+      max: new Date(2525, 11, 31, 23, 59, 59, 999)
+    })
+
+    const year = new Date(result).getFullYear()
+    t.assert(2038 <= year && year <= 2525)
+  }
+
+})


### PR DESCRIPTION
This is a breaking, because dateString() is now calculated differently and will produce different values for the same input.

I'm happy to amend the PR and avoid that breakage if it's important to remain backwards compatible.

Also, for "KISS", I simply trusts that args `min` and `max` will be of type Date. I don't know how much we should guard against misusage.  So I erred on the side of being an ass 🤡

Closes #40